### PR TITLE
Create multiple sidekiq processes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,7 +19,7 @@ Metrics/MethodLength:
   Max: 30
 
 Metrics/ClassLength:
-  Max: 130
+  Max: 140
 
 Metrics/AbcSize:
   Max: 20

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,7 +19,10 @@ Metrics/MethodLength:
   Max: 30
 
 Metrics/ClassLength:
-  Max: 120
+  Max: 130
+
+Metrics/AbcSize:
+  Max: 20
 
 RSpec/NestedGroups:
   Max: 4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v0.1.9
+
+**Fixes and enhancements:**
+
+- Allow users to specify number of sidekiq worker processes with -n flag
+
 ## v0.1.8
 
 **Fixes and enhancements:**

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Usage: sidekiq-loader [options]
     -y, --watch-delay INTEGER        [Optional] Specify the number of seconds between checking watch file. Defaults to 30.
     -d, --[no-]deploy  [FLAG]        [Optional] Deploy archive on app startup. Defaults to true.
     -s, --sidekiq-app [PATH|DIR]     [Optional] Location of application to pass to sidekiq.
+    -n, --num-procs INTEGER          [Optional] Specify the number of sidekiq processes to create. Defaults to 1.
 ```
 
 For example this will start the launcher using a S3 watch file.

--- a/bin/sidekiq-loader
+++ b/bin/sidekiq-loader
@@ -13,7 +13,7 @@ def run_sidekiq(ops, logger)
   deployer.deploy(source: deployer.archive_file) if ops[:deploy]
   config = { watch_delay: ops[:watch_delay] }
 
-  Sidekiq::Redeploy::Loader.new(deployer:, logger:, sidekiq_app: ops[:sidekiq_app], num_processes: ops[:num_processes], config:).run
+  Sidekiq::Redeploy::Loader.new(deployer:, logger:, sidekiq_app: ops[:sidekiq_app], config:, num_processes: ops[:num_processes]).run
 end
 
 def option_parser(opts)

--- a/bin/sidekiq-loader
+++ b/bin/sidekiq-loader
@@ -13,7 +13,8 @@ def run_sidekiq(ops, logger)
   deployer.deploy(source: deployer.archive_file) if ops[:deploy]
   config = { watch_delay: ops[:watch_delay] }
 
-  Sidekiq::Redeploy::Loader.new(deployer:, logger:, sidekiq_app: ops[:sidekiq_app], config:, num_processes: ops[:num_processes]).run
+  Sidekiq::Redeploy::Loader.new(deployer:, logger:, sidekiq_app: ops[:sidekiq_app], config:,
+                                num_processes: ops[:num_processes]).run
 end
 
 def option_parser(opts)

--- a/bin/sidekiq-loader
+++ b/bin/sidekiq-loader
@@ -13,7 +13,7 @@ def run_sidekiq(ops, logger)
   deployer.deploy(source: deployer.archive_file) if ops[:deploy]
   config = { watch_delay: ops[:watch_delay] }
 
-  Sidekiq::Redeploy::Loader.new(deployer:, logger:, sidekiq_app: ops[:sidekiq_app], config:).run
+  Sidekiq::Redeploy::Loader.new(deployer:, logger:, sidekiq_app: ops[:sidekiq_app], num_processes: ops[:num_processes], config:).run
 end
 
 def option_parser(opts)
@@ -38,6 +38,11 @@ def option_parser(opts)
 
     o.on '-s', '--sidekiq-app [PATH|DIR]', '[Optional] Location of application to pass to sidekiq.' do |arg|
       opts[:sidekiq_app] = arg
+    end
+
+    o.on '-n', '--num-procs INTEGER', Integer,
+         '[Optional] Specify the number of sidekiq processes to create. Defaults to 1.' do |arg|
+      opts[:num_processes] = arg
     end
   end
 end

--- a/lib/sidekiq/redeploy/loader.rb
+++ b/lib/sidekiq/redeploy/loader.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'pry'
 require 'pry-nav'
 require 'sidekiq'
@@ -160,11 +161,9 @@ module Sidekiq
       def running_pids(pids)
         new_pids = []
         pids.each do |pid|
-          begin
-            new_pids << pid unless ::Process.waitpid(pid, ::Process::WNOHANG)
-          rescue Errno::ECHILD
-            log "PID #{pid} does not exist."
-          end
+          new_pids << pid unless ::Process.waitpid(pid, ::Process::WNOHANG)
+        rescue Errno::ECHILD
+          log "PID #{pid} does not exist."
         end
         new_pids
       end

--- a/lib/sidekiq/redeploy/loader.rb
+++ b/lib/sidekiq/redeploy/loader.rb
@@ -157,8 +157,6 @@ module Sidekiq
       end
 
       def running_pids(pids)
-        return false if @exit_loader
-
         new_pids = []
         pids.each do |pid|
           new_pids << pid unless ::Process.waitpid(pid, ::Process::WNOHANG)

--- a/lib/sidekiq/redeploy/loader.rb
+++ b/lib/sidekiq/redeploy/loader.rb
@@ -65,9 +65,7 @@ module Sidekiq
             reload_app
           end
           num_dead = process_died?(@sidekiq_pids)
-          if num_dead
-            fork_sidekiq(num_dead)
-          end
+          fork_sidekiq(num_dead) if num_dead
           next unless exit_loader
 
           stop_sidekiq(@sidekiq_pids)
@@ -160,6 +158,7 @@ module Sidekiq
 
       def process_died?(pids)
         return false if @exit_loader
+
         num_dead = 0
         new_pids = []
         pids.each do |pid|

--- a/lib/sidekiq/redeploy/loader.rb
+++ b/lib/sidekiq/redeploy/loader.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'pry'
-require 'pry-nav'
 require 'sidekiq'
 require 'logger'
 

--- a/lib/sidekiq/redeploy/loader.rb
+++ b/lib/sidekiq/redeploy/loader.rb
@@ -15,9 +15,8 @@ module Sidekiq
 
       SIGNALS = [INT, TERM, USR2, TTIN].freeze
 
-      def initialize(deployer:, sidekiq_app: nil, logger: Logger.new($stdout), num_processes: 1, config: {})
+      def initialize(deployer:, sidekiq_app: nil, logger: Logger.new($stdout), config: {}, num_processes: 1)
         require 'sidekiq/cli'
-
         @reload_sidekiq = false
         @exit_loader = false
         @loader_pid = ::Process.pid
@@ -28,7 +27,7 @@ module Sidekiq
         @loop_delay = config[:loop_delay] || 0.5
         @deployer = deployer
         @sidekiq_app = sidekiq_app
-        @num_processes = num_processes
+        @num_processes = num_processes || 1
         @sidekiq_pids = []
       end
 

--- a/lib/sidekiq/redeploy/loader.rb
+++ b/lib/sidekiq/redeploy/loader.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
-
+require 'pry'
+require 'pry-nav'
 require 'sidekiq'
 require 'logger'
 
@@ -159,7 +160,11 @@ module Sidekiq
       def running_pids(pids)
         new_pids = []
         pids.each do |pid|
-          new_pids << pid unless ::Process.waitpid(pid, ::Process::WNOHANG)
+          begin
+            new_pids << pid unless ::Process.waitpid(pid, ::Process::WNOHANG)
+          rescue Errno::ECHILD
+            log "PID #{pid} does not exist."
+          end
         end
         new_pids
       end

--- a/lib/sidekiq/redeploy/version.rb
+++ b/lib/sidekiq/redeploy/version.rb
@@ -2,6 +2,6 @@
 
 module Sidekiq
   module Redeploy
-    VERSION = '0.1.8'
+    VERSION = '0.1.9'
   end
 end

--- a/spec/sidekiq/redeploy/loader_spec.rb
+++ b/spec/sidekiq/redeploy/loader_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 require 'puma-redeploy'
 
 RSpec.describe Sidekiq::Redeploy::Loader do
-  subject(:loader) { described_class.new(deployer:, logger:, config:) }
+  subject(:loader) { described_class.new(deployer:, logger:, config:, num_processes: 2) }
 
   let(:sidekiq_pid) { 456 }
   let(:loader_pid) { 123 }
@@ -29,7 +29,7 @@ RSpec.describe Sidekiq::Redeploy::Loader do
     end
 
     it 'forks process' do
-      expect(Process).to receive(:fork).and_return(sidekiq_pid)
+      expect(Process).to receive(:fork).twice.and_return(sidekiq_pid)
       loader.run
     end
 
@@ -46,14 +46,14 @@ RSpec.describe Sidekiq::Redeploy::Loader do
       it 'sends quite and shutdown signals to sidekiq process' do
         allow(Process).to receive(:fork).and_return(sidekiq_pid)
         allow(loader).to receive(:reload_sidekiq).and_return(true)
-        expect(Process).to receive(:kill).once.with('TSTP', sidekiq_pid)
-        expect(Process).to receive(:kill).twice.with('TERM', sidekiq_pid)
+        expect(Process).to receive(:kill).twice.with('TSTP', sidekiq_pid)
+        expect(Process).to receive(:kill).exactly(4).times.with('TERM', sidekiq_pid)
         loader.run
       end
 
       it 'forks sidekiq process' do
         allow(loader).to receive(:reload_sidekiq).and_return(true)
-        expect(Process).to receive(:fork).twice.and_return(sidekiq_pid)
+        expect(Process).to receive(:fork).exactly(4).times.and_return(sidekiq_pid)
         loader.run
       end
     end

--- a/spec/sidekiq/redeploy/loader_spec.rb
+++ b/spec/sidekiq/redeploy/loader_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'spec_helper'
 require 'puma-redeploy'
 
@@ -17,7 +18,7 @@ RSpec.describe Sidekiq::Redeploy::Loader do
   before do
     allow(Signal).to receive(:trap)
     allow(Process).to receive(:kill)
-    allow(loader).to receive_messages(exit_loader: true, running_pids: [456,456])
+    allow(loader).to receive_messages(exit_loader: true, running_pids: [456, 456])
   end
 
   describe '#run' do

--- a/spec/sidekiq/redeploy/loader_spec.rb
+++ b/spec/sidekiq/redeploy/loader_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-
 require 'spec_helper'
 require 'puma-redeploy'
 
@@ -18,7 +17,7 @@ RSpec.describe Sidekiq::Redeploy::Loader do
   before do
     allow(Signal).to receive(:trap)
     allow(Process).to receive(:kill)
-    allow(loader).to receive_messages(exit_loader: true, process_died?: false)
+    allow(loader).to receive_messages(exit_loader: true, running_pids: [456,456])
   end
 
   describe '#run' do
@@ -37,7 +36,7 @@ RSpec.describe Sidekiq::Redeploy::Loader do
       it 'restarts sidekiq process' do
         allow(loader).to receive(:process_died?).and_return(true)
         allow(Process).to receive(:kill)
-        expect(loader).to receive(:fork_sidekiq).twice.and_return(sidekiq_pid)
+        expect(loader).to receive(:fork_sidekiq).and_return(sidekiq_pid)
         loader.run
       end
     end


### PR DESCRIPTION
### Description

Allows users to specify number of sidekiq processes to create using the -n flag

### Your checklist for this pull request
- [ :heavy_check_mark: ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ :heavy_check_mark: ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ :heavy_check_mark: ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ :heavy_check_mark: ] I have updated the documentation accordingly.
- [ :heavy_check_mark: ] All new and existing tests passed, including Rubocop.
