### PR TITLE
Fix the order when running commands to run after unzip archive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v0.2.0
+
+**Fixes and enhancements:**
+
+- Fix the order when running commands to run after unzip archive. Also bump to 0.2.0
+
 ## v0.1.10
 
 **Fixes and enhancements:**

--- a/lib/sidekiq/redeploy/loader.rb
+++ b/lib/sidekiq/redeploy/loader.rb
@@ -67,9 +67,9 @@ module Sidekiq
 
               logger.info "Sidekiq restart begin file=#{deployer.watch_file} archive=#{archive_file}"
 
-              Puma::Redeploy::CommandRunner.new(commands: watch_file_data[:commands], logger:).run
-
               deployer.deploy(source: archive_file)
+
+              Puma::Redeploy::CommandRunner.new(commands: watch_file_data[:commands], logger:).run
             end
           elsif reload_sidekiq
             reload_app

--- a/lib/sidekiq/redeploy/version.rb
+++ b/lib/sidekiq/redeploy/version.rb
@@ -2,6 +2,6 @@
 
 module Sidekiq
   module Redeploy
-    VERSION = '0.1.10'
+    VERSION = '0.2.0'
   end
 end

--- a/sidekiq-redeploy.gemspec
+++ b/sidekiq-redeploy.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.bindir        = 'bin'
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'puma-redeploy', '~> 0.3.4'
+  spec.add_dependency 'puma-redeploy', '~> 0.4.0'
   spec.add_dependency 'sidekiq', '>= 6', '< 8'
 
   spec.metadata['rubygems_mfa_required'] = 'true'


### PR DESCRIPTION
### Description
> Fix the order when running commands to run after unzip archive

### Your checklist for this pull request
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
